### PR TITLE
qdl: refresh patch based on latest meta-qcom

### DIFF
--- a/recipes-devtools/qdl/files/0001-qdl-add-logs-indicating-flashing-progress.patch
+++ b/recipes-devtools/qdl/files/0001-qdl-add-logs-indicating-flashing-progress.patch
@@ -1,4 +1,4 @@
-From 1a58470fb5e6ed3009832bf7b74e0c3de8d50483 Mon Sep 17 00:00:00 2001
+From 5bb23a6bf8d7b5bd3c2dacb88a7b140b37cfc861 Mon Sep 17 00:00:00 2001
 From: Atul Dhudase <quic_adhudase@quicinc.com>
 Date: Fri, 8 Mar 2024 13:03:23 +0530
 Subject: [PATCH] qdl: add logs indicating flashing progress
@@ -10,26 +10,26 @@ show flashing progress.
  1 file changed, 4 insertions(+)
 
 diff --git a/firehose.c b/firehose.c
-index ebe9c524a275..bcb147c149d9 100644
+index da3ed31..8e95f49 100644
 --- a/firehose.c
 +++ b/firehose.c
-@@ -334,6 +334,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
- 	if (program->filename)
- 		xml_setpropf(node, "filename", "%s", program->filename);
+@@ -307,6 +307,7 @@ static int firehose_erase(struct qdl_device *qdl, struct program *program)
+ 	xml_setpropf(node, "num_partition_sectors", "%d", program->num_sectors);
+ 	xml_setpropf(node, "start_sector", "%s", program->start_sector);
  
 +	fprintf(stderr, "[PROGRAM] Please wait, flashing \"%s\" now...\n", program->label);
  	ret = firehose_write(qdl, doc);
  	if (ret < 0) {
  		fprintf(stderr, "[PROGRAM] failed to write program command\n");
-@@ -351,6 +352,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
- 	lseek(fd, program->file_offset * program->sector_size, SEEK_SET);
+@@ -391,6 +392,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
+ 	lseek(fd, (off_t) program->file_offset * program->sector_size, SEEK_SET);
  	left = num_sectors;
  	while (left > 0) {
 +		fprintf(stderr, "[PROGRAM] %d sectors remaining out of %d\r", left, num_sectors);
  		chunk_size = MIN(max_payload_size / program->sector_size, left);
  
  		n = read(fd, buf, chunk_size * program->sector_size);
-@@ -370,6 +372,8 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
+@@ -410,6 +412,8 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
  		left -= chunk_size;
  	}
  
@@ -37,7 +37,7 @@ index ebe9c524a275..bcb147c149d9 100644
 +
  	t = time(NULL) - t0;
  
- 	ret = firehose_read(qdl, -1, firehose_nop_parser);
+ 	ret = firehose_read(qdl, 30000, firehose_generic_parser, NULL);
 -- 
-2.25.1
+2.34.1
 

--- a/recipes-devtools/qdl/qdl_%.bbappend
+++ b/recipes-devtools/qdl/qdl_%.bbappend
@@ -1,4 +1,3 @@
-DEPENDS += "udev "
-
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
 SRC_URI:append = " file://0001-qdl-add-logs-indicating-flashing-progress.patch"


### PR DESCRIPTION
qdl was updated in meta-qcom kirkstone d44c41b49a, refresh local patch and remove udev from depends, not required.