### PR TITLE
ci: add initial kas files for the expected ci jobs

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+distro: poky
+
+defaults:
+  repos:
+    branch: master
+
+repos:
+  meta-qcom-hwe:
+
+  meta-qcom:
+    url: https://github.com/Linaro/meta-qcom
+
+  poky:
+    url: https://git.yoctoproject.org/git/poky
+    layers:
+      meta:
+      meta-poky:
+
+local_conf_header:
+  base: |
+    CONF_VERSION = "2"
+    INIT_MANAGER = "systemd"
+    PACKAGE_CLASSES = "package_ipk"
+    INHERIT += "buildstats buildstats-summary buildhistory"
+    INHERIT += "rm_work"
+
+machine: unset

--- a/ci/qcm6490-idp.yml
+++ b/ci/qcm6490-idp.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+
+machine: qcm6490-idp

--- a/ci/qcs6490-rb3gen2-core-kit.yml
+++ b/ci/qcs6490-rb3gen2-core-kit.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+
+machine: qcs6490-rb3gen2-core-kit

--- a/ci/sa8775p-ride-sx.yml
+++ b/ci/sa8775p-ride-sx.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/base.yml
+
+machine: sa8775p-ride-sx


### PR DESCRIPTION
Kas files covering the 3 initial machine configurations available as part of this layer.

Initial CI runs will cover local main plus latest revision from all the layer dependencies, using poky as distro.

meta-qcom-distro will be tested as part of the meta-qcom-distro layer.