### PR TITLE
layer.conf: decrease priority, depend on OE-Core and move to styhead

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "meta-qcom-hwe"
 BBFILE_PATTERN_meta-qcom-hwe = "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-qcom-hwe = "10"
+BBFILE_PRIORITY_meta-qcom-hwe = "5"
 
 LAYERDEPENDS_meta-qcom-hwe = "qcom"
 LAYERSERIES_COMPAT_meta-qcom-hwe = "scarthgap"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-qcom-hwe = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-qcom-hwe = "5"
 
 LAYERDEPENDS_meta-qcom-hwe = "core qcom"
-LAYERSERIES_COMPAT_meta-qcom-hwe = "scarthgap"
+LAYERSERIES_COMPAT_meta-qcom-hwe = "styhead"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS += "meta-qcom-hwe"
 BBFILE_PATTERN_meta-qcom-hwe = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-qcom-hwe = "5"
 
-LAYERDEPENDS_meta-qcom-hwe = "qcom"
+LAYERDEPENDS_meta-qcom-hwe = "core qcom"
 LAYERSERIES_COMPAT_meta-qcom-hwe = "scarthgap"


### PR DESCRIPTION
Minor fixes for layer.conf, aligning the layer priority to the base layers (and other bsp layers) and also making the dependency on oe-core explicit.