### PR TITLE
ci: add yocto-check-layer helper script

### DIFF
--- a/.github/workflows/check-layer.yml
+++ b/.github/workflows/check-layer.yml
@@ -13,6 +13,4 @@ jobs:
 
       - name: Run yocto-check-layer
         run: |
-          mkdir -p ../build
-          cd ../build
-          kas shell ../meta-qcom-hwe/ci/qcs6490-rb3gen2-core-kit.yml --command "yocto-check-layer-wrapper `pwd`/../meta-qcom-hwe --dependency `pwd`/poky/meta `pwd`/meta-qcom --no-auto-dependency"
+          ci/yocto-check-layer.sh

--- a/ci/yocto-check-layer.sh
+++ b/ci/yocto-check-layer.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -e
+
+TOPDIR=$(realpath $(dirname $(readlink -f $0))/..)
+
+# Yocto Project layer checking tool
+CMD="yocto-check-layer-wrapper"
+# Layer to check
+CMD="$CMD $TOPDIR"
+# Disable auto layer discovery
+CMD="$CMD --no-auto"
+# Layers to process for dependencies
+CMD="$CMD --dependency `pwd`/poky/meta `pwd`/meta-qcom"
+# Disable automatic testing of dependencies
+CMD="$CMD --no-auto-dependency"
+
+exec kas shell $TOPDIR/ci/base.yml --command "$CMD"


### PR DESCRIPTION
Add the yocto-check-layer with a script to be easy to replicate locally.

Also change:

- add --no-auto
  It is required if kas runs inside the bsp layer. So to make the yocto-check-layer
  happy whether it runs inside or outside it is better to have this arg.

- use the base.yml
  The --machines can be used when we need to check the layer with one or more machines.
  By default the machine is not required because the yocto-check-layer-wrapper run's
  on a clean build dir.