### PR TITLE
README: revamp readme to reflect main and the development process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,54 @@
+# meta-qcom-hwe
+
+![merge main](https://github.com/quic-yocto/meta-qcom-hwe/actions/workflows/merge-main.yml/badge.svg?branch=main)
+
 ## Introduction
-OpenEmbedded/Yocto Project layer for Qualcomm based platforms.
+
+OpenEmbedded/Yocto Project hardware enablement layer for Qualcomm based platforms.
 
 This layers provides aditional recipes and machine configuration files for Qualcomm platform.
 
 This layer depends on:
 
-| URI    | Branch |
-| -------- | ------- |
-| https://git.yoctoproject.org/meta-qcom | master |
-| https://github.com/openembedded/meta-openembedded | master |
-| https://git.yoctoproject.org/poky | master |
-| https://github.com/quic-yocto/meta-qcom-distro | main |
+```
+URI: https://github.com/openembedded/openembedded-core.git
+layers: meta
+branch: master
+revision: HEAD
+
+URI: https://github.com/Linaro/meta-qcom.git
+branch: master
+revision: HEAD
+```
+
+## Branches
+
+- **main:** Primary development branch, with focus on upstream support and compatibility with the most recent Yocto Project release.
+- **kirkstone:** Qualcomm Linux 1.x, aligned with Yocto Project 4.0 (LTS).
 
 ## Machine Support
-Supported devices are QCS6490-RB3Gen2 core-kit, QCM6490 idp and sa8775p ride-sx.
 
-To add a new machine, introduce a new machine configuration file at `layers/meta-qcom-hwe/conf/machine/`
+See `conf/machine` for the complete list of supported devices.
 
-## Build an image
+## Contributing
 
-Clone this layer and it's dependent layers:
-```
-git clone https://github.com/quic-yocto/meta-qcom-hwe.git -b main
-git clone git://git.yoctoproject.org/meta-qcom -b master
-git clone https://github.com/quic-yocto/meta-qcom-distro.git -b main
-git clone https://github.com/openembedded/meta-openembedded.git -b master
-git clone git://git.yoctoproject.org/poky -b master
-```
+Please submit any patches against the `meta-qcom-hwe` layer (branch **main**) by using the GitHub pull-request feature. Fork the repo, create a branch, do the work, rebase from upstream, and create the pull request.
 
-Initialize build environment:
-```
-source poky/oe-init-build-env
-```
-The script will cd into the newly created ```build/``` folder.
+For some useful guidelines when submitting patches, please refer to:
+https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html#preparing-changes-for-submission
 
-Update ```BBLAYERS``` in ```conf/bblayers.conf``` as shown below::
-```
-BBLAYERS ?= " \
-  <WORKSPACE>/meta-qcom \
-  <WORKSPACE>/meta-qcom-distro \
-  <WORKSPACE>/meta-qcom-hwe \
-  <WORKSPACE>/meta-openembedded/meta-python \
-  <WORKSPACE>/meta-openembedded/meta-oe \
-  <WORKSPACE>/poky/meta \
-  "
-```
-```<WORKSPACE>``` is a place holder. Please use appropriate absolute path in place of ```<WORKSACE>```.
+Pull requests will be discussed within the GitHub pull-request infrastructure.
 
+Branch **kirkstone** is not open for direct contributions, please raise an issue with the suggested change instead.
 
-Update ```MACHINE``` and ```DISTRO``` variables into ```conf/local.conf``` to:
-```
-MACHINE = "qcs6490-rb3gen2-core-kit"
-DISTRO = "qcom-wayland"
-```
+## Communication
 
-Build an image:
-```
-bitbake esp-qcom-image && bitbake qcom-console-image
-```
-This command generates ```esp``` (esp-qcom-image-<MACHINE>.rootfs-<timestamp>.vfat) and ```rootfs``` (qcom-console-image-<MACHINE>.rootfs-<timestamp>.ext4) images.
-
-```qcom-wayland``` DISTRO and ```qcom-console-image``` are defined in meta-qcom-distro layer.
+- **GitHub Issues:** [meta-qcom-hwe issues](https://github.com/quic-yocto/meta-qcom-hwe/issues)
+- **Pull Requests:** [meta-qcom-hwe pull requests](https://github.com/quic-yocto/meta-qcom-hwe/pulls)
 
 ## Maintainer(s)
-1. Naveen Kumar <quic_kumarn@quicinc.com>
-2. Sourabh Banerjee <quic_sbanerje@quicinc.com>
-3. Viswanath Kraleti <quic_vkraleti@quicinc.com>
+
+* Naveen Kumar <quic_kumarn@quicinc.com>
+* Sourabh Banerjee <quic_sbanerje@quicinc.com>
+* Viswanath Kraleti <quic_vkraleti@quicinc.com>
+* Ricardo Salveti <quic_rsalveti@quicinc.com>


### PR DESCRIPTION
Update README.md to reflect the new development process for the main branch (with a note about kirkstone), with additional information about the new contribution guidelines.

Removed meta-qcom-distro related information as it is out of scope of this repository (BSP only).