### PR TITLE
ci: Add a nightly build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,36 @@
+name: Nightly Build
+
+on:
+  schedule:
+  # NOTE - changes to the cron spec should be pushed by https://github.com/quic-yocto-ci
+  # so that build notification emails will be sent out properly.
+  - cron: "23 1 * * *"   # daily job - pick a random "minute"  - top of hour can be busy in github
+
+jobs:
+  compile:
+    strategy:
+      fail-fast: true
+      matrix:
+        machine:
+          - qcm6490-idp
+          - qcs6490-rb3gen2-core-kit
+          - sa8775p-ride-sx
+    runs-on: [self-hosted, x86]
+    name: ${{ matrix.machine }}/poky/systemd
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Kas build
+        run: |
+          # TODO - if the default branch becomes 'main', we can combine this
+          # workflow into build-yocto.yml
+          git checkout main
+          export DL_DIR=/srv/gh-runners/quic-yocto/downloads
+          export SSTATE_DIR=/srv/gh-runners/quic-yocto/sstate-cache
+          mkdir -p $DL_DIR
+          mkdir -p $SSTATE_DIR
+          mkdir build
+          cd build
+          kas build ../ci/${{ matrix.machine }}.yml


### PR DESCRIPTION
GitHub actions do scheduled runs like this on the repositories default branch. Main is not yet the default brach, so we must duplicate the build-yocto.yml workflow and have it do `git checkout main` to build.