### PR TITLE
Enable Repolinter checks on main

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -1,0 +1,30 @@
+name: QuIC Organization Repolinter
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:  
+
+jobs:
+  repolinter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Verify repolinter config file is present
+        id: check_files
+        uses: andstor/file-existence-action@v3
+        with:
+          files: "repolint.json"
+      - name: Run Repolinter with local repolint.json
+        if: steps.check_files.outputs.files_exists == 'true'
+        uses: todogroup/repolinter-action@v1
+        with:
+          config_file: "repolint.json"
+      - name: Run Repolinter with default ruleset
+        if: steps.check_files.outputs.files_exists == 'false'
+        uses: todogroup/repolinter-action@v1
+        with:
+          config_url: "https://raw.githubusercontent.com/quic/.github/main/repolint.json"

--- a/ci/yocto-check-layer.sh
+++ b/ci/yocto-check-layer.sh
@@ -1,4 +1,6 @@
 #!/bin/sh -e
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
 
 TOPDIR=$(realpath $(dirname $(readlink -f $0))/..)
 


### PR DESCRIPTION
Adds [Repolinter](https://github.com/todogroup/repolinter) checks to PRs and pushes to main. Repoliner is a TODO Group (Linux Foundation) created project that lints for common open source repo issues. 

The [config](https://github.com/quic/.github/blob/main/repolint.json) is pulled from our main QuIC org, but if we need to override we can [extend and configure it locally](https://github.com/quic/.github/tree/main?tab=readme-ov-file#customizing-repolinter-rules).

Let me know if any concerns with enabling this check on this repo. Also, should we enable for other repos such as qcom distro?