### PR TITLE
ci: lock all kas repos

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -7,18 +7,41 @@ on:
       - main
 
 jobs:
-  yocto-check-layer:
+  kas-lock:
     runs-on: [self-hosted, x86]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Run kas lock
+        run: |
+          kas dump --update --lock --inplace ci/base.yml
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: kas-lock
+          path: ci/*.lock.yml
+
+  yocto-check-layer:
+    needs: kas-lock
+    runs-on: [self-hosted, x86]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: kas-lock
+          path: ci/*.lock.yml
+
       - name: Run yocto-check-layer
         run: |
           ci/yocto-check-layer.sh
 
   compile:
+    needs: kas-lock
     strategy:
       fail-fast: true
       matrix:
@@ -32,6 +55,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: kas-lock
+          path: ci/*.lock.yml
 
       - name: Kas build
         run: |


### PR DESCRIPTION
This guarantees that the build job can be easily replicated later.
The kas will generate a file named base.lock.yml which will later
be used instead of base.yml, we will save the lock file in action
artifact in order to be shared with other jobs.

Reference:
https://kas.readthedocs.io/en/latest/userguide/project-configuration.html#working-with-lockfiles

Fixes https://github.com/quic-yocto/meta-qcom-hwe/issues/21