### PR TITLE
ci/base: add the yocto upstream sstate-mirror

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -29,5 +29,8 @@ local_conf_header:
     INHERIT += "buildstats buildstats-summary"
     INHERIT += "buildhistory"
     INHERIT += "rm_work"
+  mirror: |
+    BB_HASHSERVE_UPSTREAM = "hashserv.yocto.io:8687"
+    SSTATE_MIRRORS = "file://.* http://cdn.jsdelivr.net/yocto/sstate/all/PATH;downloadfilename=PATH"
 
 machine: unset

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -26,7 +26,8 @@ local_conf_header:
     CONF_VERSION = "2"
     INIT_MANAGER = "systemd"
     PACKAGE_CLASSES = "package_ipk"
-    INHERIT += "buildstats buildstats-summary buildhistory"
+    INHERIT += "buildstats buildstats-summary"
+    INHERIT += "buildhistory"
     INHERIT += "rm_work"
 
 machine: unset


### PR DESCRIPTION
As the development speed of the Poky master is quite fast,
we can take advantage of the sstate-cahce mirror that is made available.
This brings advantages especially when building the toolchain,
which we do not modify in any way and so we can use the existing one.

The Yocto Project now allows you to reuse the Shared State cache from its autobuilder [1].
If the network connection between our server and your machine is faster than you would build recipes from source.

[1] https://docs.yoctoproject.org/dev/migration-guides/release-notes-4.0.html?highlight=sstate_mirrors#new-features-enhancements-in-4-0