### PR TITLE
qcom-base: Swap KERNEL_IMAGETYPE and KERNEL_IMAGETYPES

### DIFF
--- a/conf/machine/include/qcom-base.inc
+++ b/conf/machine/include/qcom-base.inc
@@ -3,8 +3,8 @@
 # Provider for linux kernel
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-dev"
 
-KERNEL_IMAGETYPE ?= "Image"
-KERNEL_IMAGETYPES ?= "Image.gz"
+KERNEL_IMAGETYPE ?= "Image.gz"
+KERNEL_IMAGETYPES ?= "Image"
 
 # QDL expects 4096 aligned ext4 image for flashing
 IMAGE_FSTYPES = "ext4"


### PR DESCRIPTION
Update KERNEL_IMAGETYPE to Image.gz and KERNEL_IMAGETYPES to Image. This adjustment provides uncompressed kernel image required for the systemd-boot/UKI.