### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Reviewers to be assigned for any changes in ci/ subdirectory
+ci/*  @quaresmajose @ricardosalveti @sbanerjee-quic
+
+# Reviewers to be assigned for any changes in conf/ subdirectory
+conf/*  @quic-vkraleti @ricardosalveti @sbanerjee-quic
+
+# Reviewers to be assigned for any changes in recipes-kernel/linux/ subdirectory
+recipes-kernel/linux/*  @NainaMehtaQUIC @quic-vkraleti @sbanerjee-quic
+
+# Reviewers responsible for all changes in entire repository 
+*  @quic-vkraleti @ricardosalveti @sbanerjee-quic

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
+# Default reviewers for all changes in entire repository,
+# unless a later match takes precedence
+*  @quic-vkraleti @ricardosalveti @sbanerjee-quic
+
 # Reviewers to be assigned for any changes in ci/ subdirectory
 ci/*  @quaresmajose @ricardosalveti @sbanerjee-quic
 
@@ -6,6 +10,3 @@ conf/*  @quic-vkraleti @ricardosalveti @sbanerjee-quic
 
 # Reviewers to be assigned for any changes in recipes-kernel/linux/ subdirectory
 recipes-kernel/linux/*  @NainaMehtaQUIC @quic-vkraleti @sbanerjee-quic
-
-# Reviewers responsible for all changes in entire repository 
-*  @quic-vkraleti @ricardosalveti @sbanerjee-quic


### PR DESCRIPTION
The reviewers are assigned based on the files changed.

I am thinking the last line, i.e., rule with *, will help one of maintainers to be added as reviewers apart from the match that happens in previous lines. Thus, if there is a change in recipes-kernel/linux/ then reviewers will be assigned from both groups.
Need to test this though.