### PR TITLE
ci: qcm6490: build both esp-qcom-image and core-image-minimal images

### DIFF
--- a/ci/qcm6490.yml
+++ b/ci/qcm6490.yml
@@ -3,6 +3,4 @@
 header:
   version: 14
   includes:
-  - ci/qcm6490.yml
-
-machine: qcm6490-idp
+  - ci/base.yml

--- a/ci/qcm6490.yml
+++ b/ci/qcm6490.yml
@@ -4,3 +4,7 @@ header:
   version: 14
   includes:
   - ci/base.yml
+
+target:
+  - esp-qcom-image
+  - core-image-minimal

--- a/ci/qcs6490-rb3gen2-core-kit.yml
+++ b/ci/qcs6490-rb3gen2-core-kit.yml
@@ -3,6 +3,6 @@
 header:
   version: 14
   includes:
-  - ci/base.yml
+  - ci/qcm6490.yml
 
 machine: qcs6490-rb3gen2-core-kit


### PR DESCRIPTION
esp-qcom-image needs to be built in addition to core-image-minimal in order to have both ESP and rootfs.
