### PR TITLE
disable sstate-cache mirror by default

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -69,4 +69,4 @@ jobs:
           mkdir -p $SSTATE_DIR
           mkdir build
           cd build
-          kas build ../ci/${{ matrix.machine }}.yml
+          kas build ../ci/mirror.yml:../ci/${{ matrix.machine }}.yml

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -29,8 +29,5 @@ local_conf_header:
     INHERIT += "buildstats buildstats-summary"
     INHERIT += "buildhistory"
     INHERIT += "rm_work"
-  mirror: |
-    BB_HASHSERVE_UPSTREAM = "hashserv.yocto.io:8687"
-    SSTATE_MIRRORS = "file://.* http://cdn.jsdelivr.net/yocto/sstate/all/PATH;downloadfilename=PATH"
 
 machine: unset

--- a/ci/mirror.yml
+++ b/ci/mirror.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+local_conf_header:
+  mirror: |
+    BB_HASHSERVE_UPSTREAM = "hashserv.yocto.io:8687"
+    SSTATE_MIRRORS = "file://.* http://cdn.jsdelivr.net/yocto/sstate/all/PATH;downloadfilename=PATH"


### PR DESCRIPTION
There are situations when the upstream hash equivalent server is
not available or even if its use is not desired.