### PR TITLE
Generate dtb image for each device-tree blob of linux-yocto-dev

### DIFF
--- a/conf/machine/include/qcom-base.inc
+++ b/conf/machine/include/qcom-base.inc
@@ -6,6 +6,9 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-dev"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_IMAGETYPES ?= "Image.gz"
 
+# For dtb.bin generation
+KERNEL_CLASSES += "linux-qcom-dtbbin"
+
 # QDL expects 4096 aligned ext4 image for flashing
 IMAGE_FSTYPES = "ext4"
 IMAGE_ROOTFS_ALIGNMENT = "4096"


### PR DESCRIPTION
Inherit linux-qcom-dtbbin bbclass to generate individual dtb images for each device-tree produced by kernel. These can be flashed into dtb partition for UEFI to read and load device-tree.