### PR TITLE
qcom-qcs9100: don't weak assignment SOC_FAMILY

### DIFF
--- a/conf/machine/include/qcom-qcs9100.inc
+++ b/conf/machine/include/qcom-qcs9100.inc
@@ -1,6 +1,6 @@
 # Configurations and variables for QCS9100 SoC family.
 
-SOC_FAMILY ?= "qcs9100"
+SOC_FAMILY = "qcs9100"
 require conf/machine/include/qcom-base.inc
 require conf/machine/include/qcom-common.inc
 


### PR DESCRIPTION
The value of the SOC_FAMILY is not expected to change so assing it directly.