### PR TITLE
conf/machine: add firmware package to sa7885p ride board

### DIFF
--- a/conf/machine/sa8775p-ride-sx.conf
+++ b/conf/machine/sa8775p-ride-sx.conf
@@ -9,3 +9,8 @@ MACHINE_FEATURES = "usbhost usbgadget alsa wifi"
 KERNEL_DEVICETREE ?= " \
                       qcom/sa8775p-ride.dtb \
                       "
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    linux-firmware-qcom-adreno-a663 \
+    linux-firmware-qcom-sa8775p-adreno \
+"


### PR DESCRIPTION
Adding qcom-adreno-a663 linux
firmware packages to sa7885p ride board