### PR TITLE
ci/mirror: Fix hashequivalence server address 

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -72,7 +72,7 @@ jobs:
           export SSTATE_DIR=${CACHE_DIR}/sstate-cache
           export KAS_WORK_DIR=$PWD/../kas
           mkdir $KAS_WORK_DIR
-          kas build ci/${{ matrix.machine }}.yml
+          kas build ci/mirror.yml:ci/${{ matrix.machine }}.yml
 
       - name: Publish image
         run: |

--- a/ci/mirror.yml
+++ b/ci/mirror.yml
@@ -5,5 +5,5 @@ header:
 
 local_conf_header:
   mirror: |
-    BB_HASHSERVE_UPSTREAM = "hashserv.yocto.io:8687"
+    BB_HASHSERVE_UPSTREAM = "wss://hashserv.yoctoproject.org/ws"
     SSTATE_MIRRORS = "file://.* http://cdn.jsdelivr.net/yocto/sstate/all/PATH;downloadfilename=PATH"


### PR DESCRIPTION
Yocto upstream switched to a new server for the scarthgap
release and now the mirror is listening using websockets.

Reference: https://git.yoctoproject.org/poky/commit/?id=632e3170595bb32717c0471a55a619b4b33fe787
