### PR TITLE
Add SBOM filter to allow image distribution

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -94,3 +94,7 @@ jobs:
           (( retries == i )) && { echo 'Failed to publish artifacts'; exit 1; }
 
           echo Image available at: ${url}
+
+      - name: Clear out the generated SBOM files
+        run: |
+          find $TOPDIR -name "*.spdx" -type f -delete

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -31,3 +31,8 @@ local_conf_header:
     INHERIT += "rm_work"
 
 machine: unset
+
+post_build_filter:
+  sbom_cleanup: |
+    # Clear out the generated SBOM files
+    find $TOPDIR -name "*.spdx" -type f -delete

--- a/ci/yocto-check-layer.sh
+++ b/ci/yocto-check-layer.sh
@@ -16,3 +16,6 @@ CMD="$CMD --dependency `pwd`/poky/meta `pwd`/meta-qcom"
 CMD="$CMD --no-auto-dependency"
 
 exec kas shell $TOPDIR/ci/base.yml --command "$CMD"
+
+# Clear out the generated SBOM files
+find $TOPDIR -name "*.spdx" -type f -delete


### PR DESCRIPTION
Related to #40

Add post build filter to clear out generated SBOM files.

* Modify `ci/yocto-check-layer.sh` to include a step that uses the `find` command to locate and delete SBOM files.
* Update `ci/base.yml` to add a post build filter section that uses the `find` command to locate and delete SBOM files.
* Modify `.github/workflows/build-yocto.yml` to include a step that uses the `find` command to locate and delete SBOM files after the publish image step.

