### PR TITLE
Use GitHub poky mirror to resolve access issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Please follow the instructions below for a KAS-based build. The KAS tool offers 
 	```
 For a manual build without KAS, refer to the [Yocto Project Quick Build](https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html).
 
+Note: To avoid issues with accessing the poky upstream repository, use the GitHub mirror for poky by updating the `ci/base.yml` file to reference `https://github.com/yoctoproject/poky`.
+
 ## Contributing
 
 Please submit any patches against the `meta-qcom-hwe` layer (branch **main**) by using the GitHub pull-request feature. Fork the repo, create a branch, do the work, rebase from upstream, and create the pull request.

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -16,7 +16,7 @@ repos:
     url: https://github.com/Linaro/meta-qcom
 
   poky:
-    url: https://git.yoctoproject.org/git/poky
+    url: https://github.com/yoctoproject/poky
     layers:
       meta:
       meta-poky:


### PR DESCRIPTION
Related to #51

Update CI configuration to use GitHub mirror for poky repository

* Update `ci/base.yml` to reference `https://github.com/yoctoproject/poky` instead of `https://git.yoctoproject.org/git/poky`.
* Update `README.md` to mention using the GitHub mirror for poky to avoid access issues.

