### PR TITLE
qcm6490-idp.conf: add firmware packages

### DIFF
--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -9,3 +9,8 @@ MACHINE_FEATURES = "usbhost usbgadget alsa wifi bluetooth"
 KERNEL_DEVICETREE ?= " \
                       qcom/qcm6490-idp.dtb \
                       "
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    linux-firmware-qcom-qcm6490-audio \
+    linux-firmware-qcom-qcm6490-compute \
+"


### PR DESCRIPTION
Adding qcom-qcm6490-(audio, compute) 
firmware packages to qcm6490 idp board
