### PR TITLE
Kas persistent

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CACHE_DIR: /srv/gh-runners/quic-yocto
+  KAS_REPO_REF_DIR: /srv/gh-runners/quic-yocto/kas-mirrors
 
 jobs:
   kas-lock:

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+env:
+  CACHE_DIR: /srv/gh-runners/quic-yocto
+
 jobs:
   kas-lock:
     if: github.repository == 'quic-yocto/meta-qcom-hwe'
@@ -67,7 +70,6 @@ jobs:
 
       - name: Kas build
         run: |
-          export CACHE_DIR=/srv/gh-runners/quic-yocto
           export DL_DIR=${CACHE_DIR}/downloads
           export SSTATE_DIR=${CACHE_DIR}/sstate-cache
           export KAS_WORK_DIR=$PWD/../kas
@@ -76,7 +78,7 @@ jobs:
 
       - name: Publish image
         run: |
-          build_dir=/srv/gh-runners/quic-yocto/builds/${GITHUB_RUN_ID}
+          build_dir=${CACHE_DIR}/builds/${GITHUB_RUN_ID}
           mkdir -p $build_dir
           img_dir=$build_dir/${{ matrix.machine }}
           [ -d $img_dir ] && rm -rf $img_dir


### PR DESCRIPTION
The main change is the 2nd one, where we clone all kas repos in our persistent storage to avoid cloning each time from upstream. This variable needed to be global so that it's used in all jobs (kas-dump, check-layer and compile) since they all today clone all repos from upstream.

Since I was adding global env variables, I also added one for the persistent folder, since it was used in 2 different places already.