### PR TITLE
ci/base: add the repo path and comments to help working locally

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -13,10 +13,14 @@ repos:
   meta-qcom-hwe:
 
   meta-qcom:
+    # comment the url if you need to work out of the default branch
     url: https://github.com/Linaro/meta-qcom
+    path: meta-qcom
 
   poky:
+    # comment the url if you need to work out of the default branch
     url: https://git.yoctoproject.org/git/poky
+    path: poky
     layers:
       meta:
       meta-poky:


### PR DESCRIPTION
Add the default repo path so we can comment the url of the repo to work out of the default branch.

- kas will always change the head to the default branch when we have the 'url'
- to remove the 'url', we need to have the 'path'
- if we have the 'path' and not the 'url' kas will keep the HEAD