### PR TITLE
rb3gen2-corekit, idp confs: add firmware packages

### DIFF
--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -9,3 +9,8 @@ MACHINE_FEATURES = "usbhost usbgadget alsa wifi bluetooth"
 KERNEL_DEVICETREE ?= " \
                       qcom/qcm6490-idp.dtb \
                       "
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    linux-firmware-qcom-qcm6490-audio \
+    linux-firmware-qcom-qcm6490-compute \
+"

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -9,3 +9,8 @@ MACHINE_FEATURES = "usbhost usbgadget alsa wifi bluetooth"
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \
                       "
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    linux-firmware-qcom-qcm6490-audio \
+    linux-firmware-qcom-qcm6490-compute \
+"


### PR DESCRIPTION
Adding qcom-qcm6490-{audio, compute} firmware packages
to qcm6490-idp.conf and qcs6490-rb3gen2-core-kit.conf 
to add support of adsp and cdsp firmware