### PR TITLE
linux-yocto-dev: fix Upstream-Status for the UFS voltage patch

### DIFF
--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -5,7 +5,7 @@ FILESEXTRAPATHS:prepend:qcom := "${THISDIR}/${PN}:"
 
 SRC_URI:append:qcom = " \
     file://qcm6490-board-dts/0001-FROMLIST-arm64-dts-qcom-qcm6490-idp-Update-protected.patch \
-    file://qcm6490-board-dts/0001-PENDING-arm64-dts-qcom-qcm6490-Add-UFS-nodes-for-IDP.patch \
+    file://qcm6490-board-dts/0001-arm64-dts-qcom-qcm6490-idp-Add-UFS-nodes.patch \
     file://qcm6490-board-dts/0001-arm64-dts-qcom-sc7280-don-t-enable-GPU-on-unsupporte.patch \
     file://qcm6490-drivers/0001-firmware-qcom-scm-Introduce-CP_SMMU_APERTURE_ID.patch \
     file://qcm6490-drivers/0002-drm-msm-adreno-Setup-SMMU-aparture-for-per-process-p.patch \

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-arm64-dts-qcom-qcm6490-idp-Add-UFS-nodes.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-arm64-dts-qcom-qcm6490-idp-Add-UFS-nodes.patch
@@ -1,25 +1,23 @@
-From b51bcd8342aaaffa4d08fd3474b1512f9992886e Mon Sep 17 00:00:00 2001
+From 5b9d9b910653c53e66c05b9c4dc863d0a1ee14de Mon Sep 17 00:00:00 2001
 From: Manish Pandey <quic_mapa@quicinc.com>
-Date: Tue, 17 Oct 2023 23:46:10 +0530
-Subject: [PATCH 1/2] PENDING: arm64: dts: qcom: qcm6490: Add UFS nodes for IDP
+Date: Sat, 19 Oct 2024 12:06:59 +0530
+Subject: [PATCH] arm64: dts: qcom: qcm6490-idp: Add UFS nodes
 
-Add UFS host controller and Phy nodes for Qualcomm
-qcm6490 IDP Board.
+Add UFS host controller and Phy nodes for Qualcomm qcm6490-idp board.
 
-Change-Id: If756cf2396ad0d82e7c607738068a634c5a1919a
 Signed-off-by: Manish Pandey <quic_mapa@quicinc.com>
-Signed-off-by: Salendarsingh Gaud <quic_sgaud@quicinc.com>
-Signed-off-by: Atul Dhudase <quic_adhudase@quicinc.com>
-Upstream-Status: Pending
+Link: https://lore.kernel.org/r/20241019063659.6324-1-quic_mapa@quicinc.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [6.13]
 ---
  arch/arm64/boot/dts/qcom/qcm6490-idp.dts | 19 +++++++++++++++++++
  1 file changed, 19 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
-index 3baea71e0248..424cd9c2b092 100644
+index 5f3d4807ac43..c5fb153614e1 100644
 --- a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
 +++ b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
-@@ -463,6 +463,25 @@ &uart5 {
+@@ -702,6 +702,25 @@ &uart5 {
  	status = "okay";
  };
  
@@ -46,5 +44,5 @@ index 3baea71e0248..424cd9c2b092 100644
  	status = "okay";
  };
 -- 
-2.25.1
+2.39.5
 

--- a/recipes-kernel/linux/linux-yocto-dev/workarounds/0001-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/workarounds/0001-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch
@@ -14,7 +14,7 @@ for UFS rails.
 Signed-off-by: Umang Chheda <quic_uchheda@quicinc.com>
 Signed-off-by: Salendarsingh Gaud <quic_sgaud@quicinc.com>
 Signed-off-by: Atul Dhudase <quic_adhudase@quicinc.com>
-Upstream-Status: Pending
+Upstream-Status: Denied [https://lore.kernel.org/linux-arm-msm/jid5coqe4tpsafbi2haem6ye4vrpwyymkepduxkporfxzdi6cx@bfbodoxoq67l/]
 ---
  arch/arm64/boot/dts/qcom/qcm6490-idp.dts | 14 ++++++++++++++
  1 file changed, 14 insertions(+)


### PR DESCRIPTION
The change described in the patch isn't pending, but it has been rejected upstream. Use correct Upstream-Status for the patch.