### PR TITLE
Fix GPU support on RB3Gen2 and QCM6490 IDP

### DIFF
--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -11,6 +11,8 @@ KERNEL_DEVICETREE ?= " \
                       "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    linux-firmware-qcom-adreno-a660 \
+    linux-firmware-qcom-qcm6490-adreno \
     linux-firmware-qcom-qcm6490-audio \
     linux-firmware-qcom-qcm6490-compute \
 "

--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -6,6 +6,9 @@ FILESEXTRAPATHS:prepend:qcom := "${THISDIR}/${PN}:"
 SRC_URI:append:qcom = " \
     file://qcm6490-board-dts/0001-FROMLIST-arm64-dts-qcom-qcm6490-idp-Update-protected.patch \
     file://qcm6490-board-dts/0001-PENDING-arm64-dts-qcom-qcm6490-Add-UFS-nodes-for-IDP.patch \
+    file://qcm6490-board-dts/0001-arm64-dts-qcom-sc7280-don-t-enable-GPU-on-unsupporte.patch \
+    file://qcm6490-drivers/0001-firmware-qcom-scm-Introduce-CP_SMMU_APERTURE_ID.patch \
+    file://qcm6490-drivers/0002-drm-msm-adreno-Setup-SMMU-aparture-for-per-process-p.patch \
     file://workarounds/0001-QCLINUX-arm64-dts-qcom-qcm6490-disable-sdhc1-for-ufs.patch \
     file://workarounds/0001-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch \
 "

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-arm64-dts-qcom-sc7280-don-t-enable-GPU-on-unsupporte.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-board-dts/0001-arm64-dts-qcom-sc7280-don-t-enable-GPU-on-unsupporte.patch
@@ -1,0 +1,94 @@
+From 94d5ffab9d5ebc9caeab310f9d2eb36a65d7d3a9 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Sat, 7 Sep 2024 15:51:25 +0300
+Subject: [PATCH] arm64: dts: qcom: sc7280: don't enable GPU on unsupported
+ devices
+
+On SC7280 and derivative platforms GPU by default requires a signed
+binary, a660_zap.mbn. Disable GPU by default and enable it only when
+the binary is actually available (QCM6490-IDP, RB3gen2). ChromeOS
+devices do not use TrustZone, so GPU can be enabled by default in
+sc7280-chrome-common.dtsi. FairPhone5 and SHIFTphone8 DTS already
+enable GPU (even though it wasn't required beforehand).
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Reviewed-by: Konrad Dybcio <konradybcio@kernel.org>
+Link: https://lore.kernel.org/r/20240907-rb3g2-fixes-v1-2-eb9da98e9f80@linaro.org
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [6.13]
+---
+ arch/arm64/boot/dts/qcom/qcm6490-idp.dts           | 8 ++++++++
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts       | 8 ++++++++
+ arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi | 4 ++++
+ arch/arm64/boot/dts/qcom/sc7280.dtsi               | 2 ++
+ 4 files changed, 22 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+index 84c45419cb8d..c4cfafb3ec15 100644
+--- a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
++++ b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+@@ -499,6 +499,14 @@ vreg_bob_3p296: bob {
+ 	};
+ };
+ 
++&gpu {
++	status = "okay";
++};
++
++&gpu_zap_shader {
++	firmware-name = "qcom/qcm6490/a660_zap.mbn";
++};
++
+ &mdss {
+ 	status = "okay";
+ };
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index 5d0167fbc709..00b755779608 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -557,6 +557,14 @@ &gpi_dma1 {
+ 	status = "okay";
+ };
+ 
++&gpu {
++	status = "okay";
++};
++
++&gpu_zap_shader {
++	firmware-name = "qcom/qcs6490/a660_zap.mbn";
++};
++
+ &i2c0 {
+ 	clock-frequency = <400000>;
+ 	status = "okay";
+diff --git a/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi b/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
+index cecb3e89f7f7..eb5e32035d93 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
+@@ -56,6 +56,10 @@ &CLUSTER_PD {
+ 	domain-idle-states = <&CLUSTER_SLEEP_0>;
+ };
+ 
++&gpu {
++	status = "okay";
++};
++
+ &lpass_aon {
+ 	status = "okay";
+ };
+diff --git a/arch/arm64/boot/dts/qcom/sc7280.dtsi b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+index 3d8410683402..fbdc9c19242c 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+@@ -2823,6 +2823,8 @@ gpu: gpu@3d00000 {
+ 			nvmem-cells = <&gpu_speed_bin>;
+ 			nvmem-cell-names = "speed_bin";
+ 
++			status = "disabled";
++
+ 			gpu_zap_shader: zap-shader {
+ 				memory-region = <&gpu_zap_mem>;
+ 			};
+-- 
+2.39.5
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-drivers/0001-firmware-qcom-scm-Introduce-CP_SMMU_APERTURE_ID.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-drivers/0001-firmware-qcom-scm-Introduce-CP_SMMU_APERTURE_ID.patch
@@ -1,0 +1,91 @@
+From 1af75b2ad08bd5977c51c2d0fc11741a4c0a48d9 Mon Sep 17 00:00:00 2001
+From: Bjorn Andersson <bjorn.andersson@oss.qualcomm.com>
+Date: Sun, 10 Nov 2024 09:33:40 -0800
+Subject: [PATCH 1/2] firmware: qcom: scm: Introduce CP_SMMU_APERTURE_ID
+
+The QCOM_SCM_SVC_MP service provides QCOM_SCM_MP_CP_SMMU_APERTURE_ID,
+which is used to trigger the mapping of register banks into the SMMU
+context for per-processes page tables to function (in case this isn't
+statically setup by firmware).
+
+This is necessary on e.g. QCS6490 Rb3Gen2, in order to avoid "CP | AHB
+bus error"-errors from the GPU.
+
+Introduce a function to allow the msm driver to invoke this call.
+
+Signed-off-by: Bjorn Andersson <bjorn.andersson@oss.qualcomm.com>
+Reviewed-by: Rob Clark <robdclark@gmail.com>
+Link: https://lore.kernel.org/r/20241110-adreno-smmu-aparture-v2-1-9b1fb2ee41d4@oss.qualcomm.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [6.13]
+---
+ drivers/firmware/qcom/qcom_scm.c       | 26 ++++++++++++++++++++++++++
+ drivers/firmware/qcom/qcom_scm.h       |  1 +
+ include/linux/firmware/qcom/qcom_scm.h |  2 ++
+ 3 files changed, 29 insertions(+)
+
+diff --git a/drivers/firmware/qcom/qcom_scm.c b/drivers/firmware/qcom/qcom_scm.c
+index bdb42eb2e1e8..596a8acf0899 100644
+--- a/drivers/firmware/qcom/qcom_scm.c
++++ b/drivers/firmware/qcom/qcom_scm.c
+@@ -903,6 +903,32 @@ int qcom_scm_restore_sec_cfg(u32 device_id, u32 spare)
+ }
+ EXPORT_SYMBOL_GPL(qcom_scm_restore_sec_cfg);
+ 
++#define QCOM_SCM_CP_APERTURE_CONTEXT_MASK	GENMASK(7, 0)
++
++bool qcom_scm_set_gpu_smmu_aperture_is_available(void)
++{
++	return __qcom_scm_is_call_available(__scm->dev, QCOM_SCM_SVC_MP,
++					    QCOM_SCM_MP_CP_SMMU_APERTURE_ID);
++}
++EXPORT_SYMBOL_GPL(qcom_scm_set_gpu_smmu_aperture_is_available);
++
++int qcom_scm_set_gpu_smmu_aperture(unsigned int context_bank)
++{
++	struct qcom_scm_desc desc = {
++		.svc = QCOM_SCM_SVC_MP,
++		.cmd = QCOM_SCM_MP_CP_SMMU_APERTURE_ID,
++		.arginfo = QCOM_SCM_ARGS(4),
++		.args[0] = 0xffff0000 | FIELD_PREP(QCOM_SCM_CP_APERTURE_CONTEXT_MASK, context_bank),
++		.args[1] = 0xffffffff,
++		.args[2] = 0xffffffff,
++		.args[3] = 0xffffffff,
++		.owner = ARM_SMCCC_OWNER_SIP
++	};
++
++	return qcom_scm_call(__scm->dev, &desc, NULL);
++}
++EXPORT_SYMBOL_GPL(qcom_scm_set_gpu_smmu_aperture);
++
+ int qcom_scm_iommu_secure_ptbl_size(u32 spare, size_t *size)
+ {
+ 	struct qcom_scm_desc desc = {
+diff --git a/drivers/firmware/qcom/qcom_scm.h b/drivers/firmware/qcom/qcom_scm.h
+index 685b8f59e7a6..e36b2f67607f 100644
+--- a/drivers/firmware/qcom/qcom_scm.h
++++ b/drivers/firmware/qcom/qcom_scm.h
+@@ -116,6 +116,7 @@ struct qcom_tzmem_pool *qcom_scm_get_tzmem_pool(void);
+ #define QCOM_SCM_MP_IOMMU_SET_CP_POOL_SIZE	0x05
+ #define QCOM_SCM_MP_VIDEO_VAR			0x08
+ #define QCOM_SCM_MP_ASSIGN			0x16
++#define QCOM_SCM_MP_CP_SMMU_APERTURE_ID		0x1b
+ #define QCOM_SCM_MP_SHM_BRIDGE_ENABLE		0x1c
+ #define QCOM_SCM_MP_SHM_BRIDGE_DELETE		0x1d
+ #define QCOM_SCM_MP_SHM_BRIDGE_CREATE		0x1e
+diff --git a/include/linux/firmware/qcom/qcom_scm.h b/include/linux/firmware/qcom/qcom_scm.h
+index 9f14976399ab..4621aec0328c 100644
+--- a/include/linux/firmware/qcom/qcom_scm.h
++++ b/include/linux/firmware/qcom/qcom_scm.h
+@@ -85,6 +85,8 @@ int qcom_scm_io_writel(phys_addr_t addr, unsigned int val);
+ 
+ bool qcom_scm_restore_sec_cfg_available(void);
+ int qcom_scm_restore_sec_cfg(u32 device_id, u32 spare);
++int qcom_scm_set_gpu_smmu_aperture(unsigned int context_bank);
++bool qcom_scm_set_gpu_smmu_aperture_is_available(void);
+ int qcom_scm_iommu_secure_ptbl_size(u32 spare, size_t *size);
+ int qcom_scm_iommu_secure_ptbl_init(u64 addr, u32 size, u32 spare);
+ int qcom_scm_iommu_set_cp_pool_size(u32 spare, u32 size);
+-- 
+2.39.5
+

--- a/recipes-kernel/linux/linux-yocto-dev/qcm6490-drivers/0002-drm-msm-adreno-Setup-SMMU-aparture-for-per-process-p.patch
+++ b/recipes-kernel/linux/linux-yocto-dev/qcm6490-drivers/0002-drm-msm-adreno-Setup-SMMU-aparture-for-per-process-p.patch
@@ -1,0 +1,53 @@
+From 98e5b7f98356cef2f13b54862ca9ac016b71ff06 Mon Sep 17 00:00:00 2001
+From: Bjorn Andersson <bjorn.andersson@oss.qualcomm.com>
+Date: Sun, 10 Nov 2024 09:33:41 -0800
+Subject: [PATCH 2/2] drm/msm/adreno: Setup SMMU aparture for per-process page
+ table
+
+Support for per-process page tables requires the SMMU aparture to be
+setup such that the GPU can make updates with the SMMU. On some targets
+this is done statically in firmware, on others it's expected to be
+requested in runtime by the driver, through a SCM call.
+
+One place where configuration is expected to be done dynamically is the
+QCS6490 rb3gen2.
+
+The downstream driver does this unconditioanlly on any A6xx and newer,
+so follow suite and make the call.
+
+Signed-off-by: Bjorn Andersson <bjorn.andersson@oss.qualcomm.com>
+Reviewed-by: Rob Clark <robdclark@gmail.com>
+Link: https://lore.kernel.org/r/20241110-adreno-smmu-aparture-v2-2-9b1fb2ee41d4@oss.qualcomm.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [6.13]
+---
+ drivers/gpu/drm/msm/adreno/adreno_gpu.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/gpu/drm/msm/adreno/adreno_gpu.c b/drivers/gpu/drm/msm/adreno/adreno_gpu.c
+index 465a4cd14a43..3a40b38f2467 100644
+--- a/drivers/gpu/drm/msm/adreno/adreno_gpu.c
++++ b/drivers/gpu/drm/msm/adreno/adreno_gpu.c
+@@ -572,8 +572,19 @@ struct drm_gem_object *adreno_fw_create_bo(struct msm_gpu *gpu,
+ 
+ int adreno_hw_init(struct msm_gpu *gpu)
+ {
++	struct adreno_gpu *adreno_gpu = to_adreno_gpu(gpu);
++	int ret;
++
+ 	VERB("%s", gpu->name);
+ 
++	if (adreno_gpu->info->family >= ADRENO_6XX_GEN1 &&
++	    qcom_scm_set_gpu_smmu_aperture_is_available()) {
++		/* We currently always use context bank 0, so hard code this */
++		ret = qcom_scm_set_gpu_smmu_aperture(0);
++		if (ret)
++			DRM_DEV_ERROR(gpu->dev->dev, "unable to set SMMU aperture: %d\n", ret);
++	}
++
+ 	for (int i = 0; i < gpu->nr_rings; i++) {
+ 		struct msm_ringbuffer *ring = gpu->rb[i];
+ 
+-- 
+2.39.5
+


### PR DESCRIPTION
Pick up necessary patches and pull in firmware to enable GPU support on RB3Gen2 and QCM6490 IDP boards.

By default, even without these patches, drm/msm will attempt to bootstrap the GPU, but will fail because of the missing firmware.