### PR TITLE
README: update my email to oss.qualcomm.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Branch **kirkstone** is not open for direct contributions, please raise an issue
 * Naveen Kumar <quic_kumarn@quicinc.com>
 * Sourabh Banerjee <quic_sbanerje@quicinc.com>
 * Viswanath Kraleti <quic_vkraleti@quicinc.com>
-* Ricardo Salveti <quic_rsalveti@quicinc.com>
+* Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
 * Nicolas Dechesne <nicolas.dechesne@oss.qualcomm.com>
 
 ## License


### PR DESCRIPTION
oss.qualcomm.com is preferred instead of quicinc.com.