### PR TITLE
Add boot firmware package support for QCS9100

### DIFF
--- a/conf/machine/include/qcom-qcs9100.inc
+++ b/conf/machine/include/qcom-qcs9100.inc
@@ -9,4 +9,4 @@ require conf/machine/include/arm/arch-armv8-2a.inc
 
 KERNEL_CMDLINE_EXTRA ?= "pci=noaer pcie_pme=nomsi earlycon"
 
-EXTRA_IMAGEDEPENDS += "qcom-gen-partition-bins"
+EXTRA_IMAGEDEPENDS += "firmware-qcom-boot-qcs9100 qcom-gen-partition-bins"

--- a/recipes-bsp/firmware/firmware-qcom-boot-common.inc
+++ b/recipes-bsp/firmware/firmware-qcom-boot-common.inc
@@ -1,5 +1,13 @@
 # Install NHLOS boot binaries in DEPLOY_DIR
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
 inherit deploy
 
 do_deploy() {

--- a/recipes-bsp/firmware/firmware-qcom-boot-qcs6490_00005.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-boot-qcs6490_00005.0.bb
@@ -10,12 +10,4 @@ BOOTBINARIES = "QCM6490_bootbinaries"
 SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip"
 SRC_URI[sha256sum] = "5e597229af9103cfea5b398c7e83a05dd078a18af010a40f1b9adf92967d4c1e"
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
-
-INHIBIT_DEFAULT_DEPS = "1"
-
-do_configure[noexec] = "1"
-do_compile[noexec] = "1"
-
 include firmware-qcom-boot-common.inc

--- a/recipes-bsp/firmware/firmware-qcom-boot-qcs9100_00006.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-boot-qcs9100_00006.0.bb
@@ -1,0 +1,13 @@
+DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS9100 platform"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/Qualcomm-Technologies-Inc.-Proprietary;md5=58d50a3d36f27f1a1e6089308a49b403"
+
+FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_integrationandtest_publictest"
+FW_BUILD_ID = "r1.0_${PV}/qcs9100-le-1-0"
+FW_BIN_PATH = "common/build/ufs/bin"
+BOOTBINARIES = "QCS9100_bootbinaries"
+
+SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip"
+SRC_URI[sha256sum] = "480682759e27d63b0e44501ae2517b3671bea6dad21071880a22ed5feb5a458b"
+
+include firmware-qcom-boot-common.inc


### PR DESCRIPTION
Add the boot firmware package to install boot binaries for the QCS9100 based boards.

While at it, consolidate common code into firmware-qcom-boot-common.inc to avoid repetition.