### PR TITLE
ci: yocto-check-layer: set BSP machines to be tested

### DIFF
--- a/ci/yocto-check-layer.sh
+++ b/ci/yocto-check-layer.sh
@@ -14,5 +14,7 @@ CMD="$CMD --no-auto"
 CMD="$CMD --dependency `pwd`/poky/meta `pwd`/meta-qcom"
 # Disable automatic testing of dependencies
 CMD="$CMD --no-auto-dependency"
+# Set machines to all machines defined in this BSP layer
+CMD="$CMD --machines $(echo $(find $TOPDIR/conf/machine/ -maxdepth 1 -name *.conf -exec basename {} .conf \; ))"
 
 exec kas shell $TOPDIR/ci/base.yml --command "$CMD"

--- a/ci/yocto-check-layer.sh
+++ b/ci/yocto-check-layer.sh
@@ -4,6 +4,10 @@
 
 TOPDIR=$(realpath $(dirname $(readlink -f $0))/..)
 
+# Ensure KAS workspace is outside of the checked out repo
+# Allows the caller to specify KAS_WORK_DIR, otherwise make temp one
+export KAS_WORK_DIR=$(realpath ${KAS_WORK_DIR:-$(mktemp -d)})
+
 # Yocto Project layer checking tool
 CMD="yocto-check-layer-wrapper"
 # Layer to check
@@ -11,10 +15,11 @@ CMD="$CMD $TOPDIR"
 # Disable auto layer discovery
 CMD="$CMD --no-auto"
 # Layers to process for dependencies
-CMD="$CMD --dependency `pwd`/poky/meta `pwd`/meta-qcom"
+CMD="$CMD --dependency $KAS_WORK_DIR/poky/meta $KAS_WORK_DIR/meta-qcom"
 # Disable automatic testing of dependencies
 CMD="$CMD --no-auto-dependency"
 # Set machines to all machines defined in this BSP layer
 CMD="$CMD --machines $(echo $(find $TOPDIR/conf/machine/ -maxdepth 1 -name *.conf -exec basename {} .conf \; ))"
 
+echo "Running kas in $KAS_WORK_DIR"
 exec kas shell $TOPDIR/ci/base.yml --command "$CMD"


### PR DESCRIPTION
When running yocto-check-layer, we can see the following logs:

INFO: test_machine_signatures (bsp.BSPCheckLayer)
INFO:  ... skipped 'No machines set with --machines.'
INFO: No machines set with --machines.
INFO: test_machine_world (bsp.BSPCheckLayer)
INFO:  ... skipped 'No machines set with --machines.'
INFO: No machines set with --machines.

Because we do not set --machines when running the script, it does not try to run the tests with each individual machine. When setting machines, yocto-check-layer will ensure that all signatures do not change when setting MACHINE for each our supported machine. So we can catch more errors. Note that this is also what would be done by Yocto if we wanted to run the compliance tests.

E.g. from Yocto docs:

bsp.test_machine_world: Verifies that bitbake world works regardless
                        of which machine is selected.

bsp.test_machine_signatures: Verifies that building for a particular
                             machine affects only the signature of
                             tasks specific to that machine.