### PR TITLE
ci: yocto-patchreview: run blame command to get additional context

### DIFF
--- a/ci/yocto-patchreview.sh
+++ b/ci/yocto-patchreview.sh
@@ -8,9 +8,8 @@ TOPDIR=$(realpath $(dirname $(readlink -f $0))/..)
 # Allows the caller to specify KAS_WORK_DIR, otherwise make temp one
 export KAS_WORK_DIR=$(realpath ${KAS_WORK_DIR:-$(mktemp -d)})
 
-# TODO: add -b option when https://lore.kernel.org/openembedded-core/20241119094109.2648950-1-nicolas.dechesne@oss.qualcomm.com/T/#u is merged
 echo "Running kas in $KAS_WORK_DIR"
-kas shell $TOPDIR/ci/base.yml --command "$KAS_WORK_DIR/poky/scripts/contrib/patchreview.py -v -j status.json $TOPDIR"
+kas shell $TOPDIR/ci/base.yml --command "$KAS_WORK_DIR/poky/scripts/contrib/patchreview.py -v -b -j status.json $TOPDIR"
 
 # return an error if any malformed patch is found
 cat $KAS_WORK_DIR/build/status.json |


### PR DESCRIPTION
When a patch is malformed, the patchreview script can run a git blame command on the patch to provide additional contextual data. The --blame command was failing, and a fix was found, now that this patch is merged in poky:

79ef781499f5 (scripts: patchreview: fix failure when running from a different folder)

we can enable --blame in our script.