### PR TITLE
firmware: set the download filename

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-boot-qcs6490_00005.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-boot-qcs6490_00005.0.bb
@@ -7,7 +7,7 @@ FW_BUILD_ID = "r1.0_${PV}/qcm6490-le-1-0"
 FW_BIN_PATH = "common/build/ufs/bin"
 BOOTBINARIES = "QCM6490_bootbinaries"
 
-SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip"
+SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip"
 SRC_URI[sha256sum] = "5e597229af9103cfea5b398c7e83a05dd078a18af010a40f1b9adf92967d4c1e"
 
 include firmware-qcom-boot-common.inc

--- a/recipes-bsp/firmware/firmware-qcom-boot-qcs9100_00006.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-boot-qcs9100_00006.0.bb
@@ -7,7 +7,7 @@ FW_BUILD_ID = "r1.0_${PV}/qcs9100-le-1-0"
 FW_BIN_PATH = "common/build/ufs/bin"
 BOOTBINARIES = "QCS9100_bootbinaries"
 
-SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip"
+SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip"
 SRC_URI[sha256sum] = "480682759e27d63b0e44501ae2517b3671bea6dad21071880a22ed5feb5a458b"
 
 include firmware-qcom-boot-common.inc


### PR DESCRIPTION
The boot firmware files published by Qualcomm, even if they are versioned properly, are pusblished as
<platform>_bootbinaries.zip. Bitbake expects the version to be there in the downloaded filenames, since all downloads are placed in the same location (DL_DIR). As such installing different versions of the boot binaries will override them each time, and bitbake complains about that (and it causes unnecessary warnings and re-fetch).

We can customize the download file name using the 'downloadfilename' attribute in SRC_URI. With this patch, the firmware is downloaded as:

downloads/QCM6490_bootbinaries_r1.0_00005.0.zip