### PR TITLE
qcom-base: append IMAGE_FSTYPES instead of set

### DIFF
--- a/conf/machine/include/qcom-base.inc
+++ b/conf/machine/include/qcom-base.inc
@@ -10,7 +10,7 @@ KERNEL_IMAGETYPES ?= "Image.gz"
 KERNEL_CLASSES += "linux-qcom-dtbbin"
 
 # QDL expects 4096 aligned ext4 image for flashing
-IMAGE_FSTYPES = "ext4"
+IMAGE_FSTYPES += "ext4"
 IMAGE_ROOTFS_ALIGNMENT = "4096"
 EXTRA_IMAGECMD:ext4 = "-i 4096 -b 4096"
 


### PR DESCRIPTION
Set overrides any other value previously set by the user (e.g. local.conf), so change to use += (append) instead.