### PR TITLE
qcom-base: QCOM_BOOTIMG_ROOTFS: use PARTLABEL

### DIFF
--- a/conf/machine/include/qcom-base.inc
+++ b/conf/machine/include/qcom-base.inc
@@ -16,5 +16,5 @@ EXTRA_IMAGECMD:ext4 = "-i 4096 -b 4096"
 
 SERIAL_CONSOLES ?= "115200;ttyMSM0"
 
-QCOM_BOOTIMG_ROOTFS ?= "/dev/disk/by-partlabel/system"
+QCOM_BOOTIMG_ROOTFS ?= "PARTLABEL=system"
 


### PR DESCRIPTION
Kernel is only able to recognize PARTLABEL when root specifies a block device using partition label.