### PR TITLE
qcm6490-partitions: drop ssd and keystore from lun 0

### DIFF
--- a/recipes-bsp/partition/qcom-partition-confs/qcm6490-partitions.conf
+++ b/recipes-bsp/partition/qcom-partition-confs/qcm6490-partitions.conf
@@ -19,8 +19,6 @@
 #   --sparse      false
 
 #This is LUN 0 - HLOS LUN
---partition --lun=0 --name=ssd --size=8KB --type-guid=2C86E742-745E-4FDD-BFD8-B6A7AC638772
---partition --lun=0 --name=keystore --size=512KB --type-guid=DE7D4029-0F5B-41C8-AE7E-F6C023A02B33
 --partition --lun=0 --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
 --partition --lun=0 --name=system --size=23099392KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=system.img
 


### PR DESCRIPTION
Partitions not currently used by Qualcomm Linux.