### PR TITLE
ci: base: allow root with empty password

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -29,5 +29,7 @@ local_conf_header:
     INHERIT += "buildstats buildstats-summary"
     INHERIT += "buildhistory"
     INHERIT += "rm_work"
+  extra: |
+    EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
 
 machine: unset


### PR DESCRIPTION
Follow poky sample conf and add allow-empty-password, empty-root-password and allow-root-login to EXTRA_IMAGE_FEATURES, since there is no default user and password on the standard poky configuration.