### PR TITLE
ci: yocto-check-layer: run KAS with debug

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: kas-lock
-          path: ci/*.lock.yml
+          path: ci/
 
       - name: Run yocto-check-layer
         run: |
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: kas-lock
-          path: ci/*.lock.yml
+          path: ci/
 
       - name: Run Yocto patchreview
         run: |
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: kas-lock
-          path: ci/*.lock.yml
+          path: ci/
 
       - name: Kas build
         run: |


### PR DESCRIPTION
For some reasons, kas does not checkout what we expect. The lock yaml files contain the most recent commits from poky and meta-qcom, which is expected since we run kas dump --update, however the downstream kas commands checkout the latest commits in the local mirror, not what we set in the lock files.

Let's add some debug to observe what is happening during the build.