### PR TITLE
ci: build core-image-base instead of core-image-minimal

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -36,3 +36,6 @@ local_conf_header:
     EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
 
 machine: unset
+
+target:
+  - core-image-base

--- a/ci/qcm6490.yml
+++ b/ci/qcm6490.yml
@@ -4,7 +4,3 @@ header:
   version: 14
   includes:
   - ci/base.yml
-
-target:
-  - esp-qcom-image
-  - core-image-minimal


### PR DESCRIPTION
* Specify core-image-base as the default target
* Drop specific target list for qcm6490 as esp-qcom-image is now built by default when qcomflash is used