### PR TITLE
Add EFI support to MACHINE_FEATURES

### DIFF
--- a/conf/machine/qcm6490-idp.conf
+++ b/conf/machine/qcm6490-idp.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs6490.inc
 
-MACHINE_FEATURES = "usbhost usbgadget alsa wifi bluetooth"
+MACHINE_FEATURES = "efi usbhost usbgadget alsa wifi bluetooth"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcm6490-idp.dtb \

--- a/conf/machine/qcs6490-rb3gen2-core-kit.conf
+++ b/conf/machine/qcs6490-rb3gen2-core-kit.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs6490.inc
 
-MACHINE_FEATURES = "usbhost usbgadget alsa wifi bluetooth"
+MACHINE_FEATURES = "efi usbhost usbgadget alsa wifi bluetooth"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/qcs6490-rb3gen2.dtb \

--- a/conf/machine/sa8775p-ride-sx.conf
+++ b/conf/machine/sa8775p-ride-sx.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/qcom-qcs9100.inc
 
-MACHINE_FEATURES = "usbhost usbgadget alsa wifi"
+MACHINE_FEATURES = "efi usbhost usbgadget alsa wifi"
 
 KERNEL_DEVICETREE ?= " \
                       qcom/sa8775p-ride.dtb \


### PR DESCRIPTION
Add missing EFI support in MACHINE_FEATURES for all the current machines supported by this layer, since they all have an EFI-based bootloader.