### PR TITLE
ci: base: set IMAGE_ROOTFS_EXTRA_SPACE

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -34,6 +34,7 @@ local_conf_header:
     IMAGE_FSTYPES += "qcomflash"
   extra: |
     EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
+    IMAGE_ROOTFS_EXTRA_SPACE = "307200"
 
 machine: unset
 


### PR DESCRIPTION
Add minimal extra space of 300mb to the images built with base.

This is needed until we have a resizefs logic in place on first boot.