### PR TITLE
layer.conf: increase BBFILE_PRIORITY to 6

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "qcom-hwe"
 BBFILE_PATTERN_qcom-hwe = "^${LAYERDIR}/"
-BBFILE_PRIORITY_qcom-hwe = "5"
+BBFILE_PRIORITY_qcom-hwe = "6"
 
 LAYERDEPENDS_qcom-hwe = "core qcom"
 LAYERSERIES_COMPAT_qcom-hwe = "styhead walnascar"


### PR DESCRIPTION
This gets us slightly more deterministic behaviour since most layers, inclusing OE-core, set it to 5. When priorities are equal, the ordering in BBLAYERS is used to resolve conflicts. Since this layer was at '5', getting the ordering wrong would negate .bbappends and shadowed recipes.

Upstream bitbake wants to phase this out, but for the time being, let's decrease the opportunities for users to get this wrong.

Fixes: https://github.com/quic-yocto/meta-qcom-hwe/issues/98