### PR TITLE
workflows: pass secret in nightly build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -9,3 +9,4 @@ on:
 jobs:
   nightly:
     uses: ./.github/workflows/build-yocto.yml
+    secrets: inherit


### PR DESCRIPTION
When calling reusable workflow the secrets are not passed by default. This patch fixes the issue of missing LAVA token.