### PR TITLE
ci: base: enable efi in DISTRO_FEATURES

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -33,6 +33,7 @@ local_conf_header:
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"
   extra: |
+    DISTRO_FEATURES:append = " efi"
     EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
     IMAGE_ROOTFS_EXTRA_SPACE = "307200"
 


### PR DESCRIPTION
Enable efi in DISTRO_FEATURES in order to enable efi support in systemd, which provides a better integration with systemd-boot, bootctl and efi runtime support.