### PR TITLE
ci/base.yml: convert to nodistro

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -3,7 +3,7 @@
 header:
   version: 14
 
-distro: poky
+distro: nodistro
 
 defaults:
   repos:
@@ -15,11 +15,15 @@ repos:
   meta-qcom:
     url: https://github.com/Linaro/meta-qcom
 
-  poky:
-    url: https://git.yoctoproject.org/git/poky
+  oe-core:
+    url: https://git.openembedded.org/openembedded-core
     layers:
       meta:
-      meta-poky:
+
+  bitbake:
+    url: https://git.openembedded.org/bitbake
+    layers:
+      .: excluded
 
 local_conf_header:
   base: |

--- a/ci/yocto-check-layer.sh
+++ b/ci/yocto-check-layer.sh
@@ -15,7 +15,7 @@ CMD="$CMD $TOPDIR"
 # Disable auto layer discovery
 CMD="$CMD --no-auto"
 # Layers to process for dependencies
-CMD="$CMD --dependency $KAS_WORK_DIR/poky/meta $KAS_WORK_DIR/meta-qcom"
+CMD="$CMD --dependency $KAS_WORK_DIR/oe-core/meta $KAS_WORK_DIR/meta-qcom"
 # Disable automatic testing of dependencies
 CMD="$CMD --no-auto-dependency"
 # Set machines to all machines defined in this BSP layer

--- a/ci/yocto-patchreview.sh
+++ b/ci/yocto-patchreview.sh
@@ -9,7 +9,7 @@ TOPDIR=$(realpath $(dirname $(readlink -f $0))/..)
 export KAS_WORK_DIR=$(realpath ${KAS_WORK_DIR:-$(mktemp -d)})
 
 echo "Running kas in $KAS_WORK_DIR"
-kas shell $TOPDIR/ci/base.yml --command "$KAS_WORK_DIR/poky/scripts/contrib/patchreview.py -v -b -j status.json $TOPDIR"
+kas shell $TOPDIR/ci/base.yml --command "$KAS_WORK_DIR/oe-core/scripts/contrib/patchreview.py -v -b -j status.json $TOPDIR"
 
 # return an error if any malformed patch is found
 cat $KAS_WORK_DIR/build/status.json |


### PR DESCRIPTION
Since Poky is both not meant nor suited for production, it shouldn't be the default choice for reference builds, downstream users tend to keep to the defaults, even the wrong ones.

Furthermore, since the configs are adding additional classes and changes, the result is not identical to upstream Poky anymore, leading to more confusion.

Switch to using straight OE-core and bitbake repos and set DISTRO to 'nodistro'.

Boot tested on rb3gen2:
```
root@qcs6490-rb3gen2-core-kit:~# cat /etc/os-release 
ID=nodistro
NAME="OpenEmbedded"
VERSION="nodistro.0"
VERSION_ID=nodistro.0
PRETTY_NAME="OpenEmbedded nodistro.0"
CPE_NAME="cpe:/o:openembedded:nodistro:nodistro.0"
```