### PR TITLE
ci: update github org name for the repolinter workflow

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   repolinter:
-    if: github.repository == 'quic-yocto/meta-qcom-hwe'
+    if: github.repository == 'qualcomm-linux/meta-qcom-hwe'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Org was renamed from quic-yocto to qualcomm-linux.