### PR TITLE
layer.conf: Ignore QCOM_COMMON_LICENSE_DIR variable in hash calculation

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -33,6 +33,7 @@ BBFILES_DYNAMIC += " \
 "
 
 QCOM_COMMON_LICENSE_DIR = "${@os.path.normpath("${LAYERDIR}")+'/files/common-licenses/'}"
+LIC_FILES_CHKSUM[vardepsexclude] += "QCOM_COMMON_LICENSE_DIR"
 
 # Set a variable to get to the top of this metalayer
 QCOMHWEBASE = '${@os.path.normpath("${LAYERDIR}")}'


### PR DESCRIPTION
Since TOPDIR is appended to the LAYERDIR path contained in this variable, building from a different directory reduces the sstate-cache hit rate for recipes that use QCOM_COMMON_LICENSE_DIR.

```
TOPDIR1/tmp/sstate-diff/1759133466/qcs6490-rb3gen2-vision-kit/<TRIPLE>/time-genoff $ bitbake-diffsigs ./15.0.do_package.sigdata.28f71c835e5ca367eadc9011ae70403e8cb2bf33b8ae20fa040df5d69dfb6cfe \
TOPDIR2/tmp/sstate-diff/1759133333/qcs6490-rb3gen2-vision-kit/<TRIPLE>/time-genoff/15.0.do_package.sigdata.9eabc9947518db7de3427e8da226b6650ad4b3dad7b6659cbb21245a28460a32
NOTE: Starting bitbake server...
basehash changed from 9990fb107900393658bf819b17528ee4810cefe6d09660e6320eccc4e119dac0 to 327c12e7c95192e2d172d7022c2bdbadd292b5a687b0acc1ab939f19c2f7d216
Variable QCOM_COMMON_LICENSE_DIR value changed from '${@os.path.normpath("TOPDIR1/meta-qcom/meta-qcom-hwe")+'/files/common-licenses/'}' to '${@os.path.normpath("TOPDIR2/meta-qcom/meta-qcom-hwe")+'/files/common-licenses/'}'
```