### PR TITLE
Fix libdrm PACKAGECONFIG appending

### DIFF
--- a/recipes-graphics/drm/libdrm_%.bbappend
+++ b/recipes-graphics/drm/libdrm_%.bbappend
@@ -4,4 +4,4 @@ SRC_URI:append:qcom = " \
     file://0001-libdrm-Export-libdrm_macros.h-header.patch \
 "
 
-PACKAGECONFIG:append = "libkms"
+PACKAGECONFIG:append = " libkms"


### PR DESCRIPTION
The append operator doesn't add whitespaces automatically so this may create an invalid configuration.

Fixes build warning:
QA Issue: libdrm-native: invalid PACKAGECONFIG: install-test-programslibkms [invalid-packageconfig]