### PR TITLE
Fix whitespace bug in systemd bbappend

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
-SRC_URI:append:qcom = "file://0001-QCLINUX-units-adjust-timeout-for-systemd-networkd-wa.patch \
+SRC_URI:append:qcom = " file://0001-QCLINUX-units-adjust-timeout-for-systemd-networkd-wa.patch \
 		      "
 
 # Enable coredump support


### PR DESCRIPTION
The append syntax does not contain whitespaces.
This potentially breaks other layers that append to systemd as well.