### PR TITLE
hostap-daemon: Set CVE_PRODUCT to hostapd

### DIFF
--- a/recipes-connectivity/hostap-daemon/hostap-daemon.inc
+++ b/recipes-connectivity/hostap-daemon/hostap-daemon.inc
@@ -11,3 +11,5 @@ DEPENDS = "openssl libnl"
 do_install() {
 	make install DESTDIR=${D} BINDIR=${sbindir}/
 }
+
+CVE_PRODUCT = "hostapd"

--- a/recipes-connectivity/hostap-daemon/hostap-daemon_6.0.qcom.bb
+++ b/recipes-connectivity/hostap-daemon/hostap-daemon_6.0.qcom.bb
@@ -24,3 +24,5 @@ do_configure() {
         install -m 0644 ${WORKDIR}/misc/defconfig .config
         echo "CFLAGS +=\"-I${STAGING_INCDIR}/libnl3\"" >> .config
 }
+
+CVE_VERSION = "2.11"


### PR DESCRIPTION
This recipe installs hostapd from hostap.git, but the default CVE metadata comes from hostap-daemon and 6.0.qcom. 

That does not match the upstream product/version used by sbom-cve-check, so hostapd CVEs are not mapped correctly.

Set CVE_PRODUCT to hostapd and CVE_VERSION to 2.11 to match the upstream source used by this recipe.