### PR TITLE
msm_be.bb: Add CVE_PRODUCT and CVE_VERSION variables

### DIFF
--- a/recipes-graphics/msm_be/msm_be.bb
+++ b/recipes-graphics/msm_be/msm_be.bb
@@ -11,9 +11,11 @@ LIC_FILES_CHKSUM = "file://docs/license.rst;md5=63779ec98d78d823a9dc533a0735ef10
 PE = "2"
 PV = "1.0"
 
+MESA_VERSION = "24.0.7"
+
 PROVIDES += "virtual/libgbm"
 
-SRC_URI = "https://mesa.freedesktop.org/archive/mesa-24.0.7.tar.xz \
+SRC_URI = "https://mesa.freedesktop.org/archive/mesa-${MESA_VERSION}.tar.xz \
            file://0001-meson-misdetects-64bit-atomics-on-mips-clang.patch \
            file://0001-drisw-fix-build-without-dri3.patch \
            file://0002-glxext-don-t-try-zink-if-not-enabled-in-mesa.patch \
@@ -23,7 +25,7 @@ SRC_URI = "https://mesa.freedesktop.org/archive/mesa-24.0.7.tar.xz \
            file://0001-avoid-install-header.patch \
 "
 
-S = "${WORKDIR}/mesa-24.0.7"
+S = "${WORKDIR}/mesa-${MESA_VERSION}"
 
 SRC_URI[sha256sum] = "7454425f1ed4a6f1b5b107e1672b30c88b22ea0efea000ae2c7d96db93f6c26a"
 
@@ -354,3 +356,6 @@ RCONFLICTS:mesa-megadriver = "mesa"
 RPROVIDES:mesa-megadriver = "mesa"
 
 RPROVIDES:${PN} += "virtual/libgbm"
+
+CVE_PRODUCT = "mesa"
+CVE_VERSION = "${MESA_VERSION}"


### PR DESCRIPTION
Since msm uses mesa version 24.0.7, add CVE_PRODUCT and CVE_VERSION variables to facilitate vulnerability management.
Previously, CVE_PRODUCT was recognized as msm and the version as be in cpe, which caused false positives in sbom-cve-check as follows:

{
    "id": "CVE-2023-33284",
    "status": "Patched",
    "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-33284",
    "summary": "Marval MSM through 14.19.0.12476 and 15.0 has a Remote Code Execution vulnerability. A remote attacker authenticated as any user is able to execute code in context of the web server.",
    "scorev2": "0.0",
    "scorev3": "8.8",
    "scorev4": "0.0",
    "modified": "2026-06-17T06:01:29.000",
    "vector": "NETWORK",
    "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
    "detail": "version-not-in-range: Only affects 15.0 onwards"
}
],
"cpes": [
"cpe:2.3:*:*:msm:be:*:*:*:*:*:*:*"
]