### PR TITLE
libdrm: add the missing space to the PACKAGECONFIG append

### DIFF
--- a/recipes-graphics/drm/libdrm_%.bbappend
+++ b/recipes-graphics/drm/libdrm_%.bbappend
@@ -4,4 +4,4 @@ SRC_URI:append:qcom = " \
     file://0001-libdrm-Export-libdrm_macros.h-header.patch \
 "
 
-PACKAGECONFIG:append = "libkms"
+PACKAGECONFIG:append = " libkms"


### PR DESCRIPTION
Without a leading space the append glues itself onto the last entry of libdrm's default PACKAGECONFIG and swallows it.

Note that libkms support was already removed from oe-core in 3c250b743bce ("libdrm: Remove libdrm-kms package").